### PR TITLE
Updated targeted runtime for publishing

### DIFF
--- a/.github/workflows/package-and-upload.yml
+++ b/.github/workflows/package-and-upload.yml
@@ -9,7 +9,7 @@ jobs:
   feature_test:
     runs-on: ubuntu-latest
     env:
-      TARGET_RUNTIME: rhel.7.2-x64
+      TARGET_RUNTIME: linux-x64
       LAMBDA_FOLDER: Lambda
       S3_BUCKET: stephen-teodori-doctor-who
       CONFIG: Release


### PR DESCRIPTION
Updated targeting publish runtime from `rhel.7.2-x64` to `linux-x64`. [Documentation](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog) indicates that rhel past version 6 uses linux under the hood anyway? Additional research required? 